### PR TITLE
Fixes Calls to Netty API:

### DIFF
--- a/src/main/java/org/waarp/gateway/ftp/adminssl/HttpSslHandler.java
+++ b/src/main/java/org/waarp/gateway/ftp/adminssl/HttpSslHandler.java
@@ -34,11 +34,11 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
@@ -783,8 +783,8 @@ public class HttpSslHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         responseContent.setLength(0);
 
         // Decide whether to close the connection or not.
-        boolean keepAlive = HttpHeaderUtil.isKeepAlive(request);
-        boolean close = HttpHeaderValues.CLOSE.equalsIgnoreCase(request
+        boolean keepAlive = HttpUtil.isKeepAlive(request);
+        boolean close = HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(request
                 .headers().get(HttpHeaderNames.CONNECTION)) ||
                 (!keepAlive) || forceClose;
 


### PR DESCRIPTION
- io.netty.handler.codec.http.HttpHeaderUtil has been removed and merged into
  import io.netty.handler.codec.http.HttpUtil

- AsciiString type has no public method equalsIgnoreCase. contentEqualsIgnoreCase must be
  used instead (this type is used for HttpHeaderValues items)