### PR TITLE
QUIT was always answered with "421 Post operations cannot be done so force disconnection"

### DIFF
--- a/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
+++ b/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
@@ -214,13 +214,8 @@ public class ExecBusinessHandler extends BusinessHandler {
 
     @Override
     public void afterRunCommandOk() throws CommandAbstractException {
-        // nothing to do since it is only Command and not transfer
-        // except if QUIT due to database error
         if (!(this.getFtpSession().getCurrentCommand() instanceof QUIT)
                 && this.dbR66Session != null) {
-            throw new Reply421Exception(
-                    "Post operations cannot be done so force disconnection... Try again later on");
-        } else {
             long specialId =
                     ((FileBasedAuth) getFtpSession().getAuth()).getSpecialId();
             WaarpActionLogger.logAction(dbFtpSession, specialId,

--- a/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
+++ b/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
@@ -214,13 +214,7 @@ public class ExecBusinessHandler extends BusinessHandler {
 
     @Override
     public void afterRunCommandOk() throws CommandAbstractException {
-        // nothing to do since it is only Command and not transfer
-        // except if QUIT due to database error
-        if (this.getFtpSession().getCurrentCommand() instanceof QUIT
-                && this.dbR66Session == null) {
-            throw new Reply421Exception(
-                    "Post operations cannot be done so force disconnection... Try again later on");
-        } else {
+        if (this.dbR66Session != null) {
             long specialId =
                     ((FileBasedAuth) getFtpSession().getAuth()).getSpecialId();
             WaarpActionLogger.logAction(dbFtpSession, specialId,

--- a/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
+++ b/src/main/java/org/waarp/gateway/ftp/control/ExecBusinessHandler.java
@@ -214,7 +214,13 @@ public class ExecBusinessHandler extends BusinessHandler {
 
     @Override
     public void afterRunCommandOk() throws CommandAbstractException {
-        if (this.dbR66Session != null) {
+        // nothing to do since it is only Command and not transfer
+        // except if QUIT due to database error
+        if (!(this.getFtpSession().getCurrentCommand() instanceof QUIT)
+                && this.dbR66Session != null) {
+            throw new Reply421Exception(
+                    "Post operations cannot be done so force disconnection... Try again later on");
+        } else {
             long specialId =
                     ((FileBasedAuth) getFtpSession().getAuth()).getSpecialId();
             WaarpActionLogger.logAction(dbFtpSession, specialId,


### PR DESCRIPTION
Even a simple FTP session like :

    ---> Connection
    <--- 220 SERVICE READY
    ---> QUIT
    <--- 421 Post operations cannot be done so force disconnection

was answered with this message, which is misleading :
the test `(this.getFtpSession().getCurrentCommand() instanceof QUIT
 && this.dbR66Session == null)` is always true (if the command is QUIT,
no db comnnection is made because none is required, so it is always null)
and the message is misleading: it seemes like an error, but it is not.

@fredericBregier Did I overlooked any use case ?