### PR TITLE
Use logging rather than stderr or stdout output when it makes sense.

### DIFF
--- a/src/main/java/org/waarp/gateway/ftp/ExecGatewayFtpServer.java
+++ b/src/main/java/org/waarp/gateway/ftp/ExecGatewayFtpServer.java
@@ -74,6 +74,7 @@ public class ExecGatewayFtpServer {
             configuration.getShutdownConfiguration().serviceFuture = FtpEngine.closeFuture;
         }
         if (!configuration.setConfigurationServerFromXml(config)) {
+            logger.error("Bad main configuration");
             System.err.println("Bad main configuration");
             return false;
         }
@@ -84,15 +85,16 @@ public class ExecGatewayFtpServer {
                 if (!org.waarp.openr66.configuration.FileBasedConfiguration
                         .setSubmitClientConfigurationFromXml(Configuration.configuration,
                                 r66file)) {
+                    logger.error("Bad R66 configuration");
                     System.err.println("Bad R66 configuration");
                     return false;
                 }
             } else {
                 // Cannot get R66 functional
-                System.err.println("No R66PrepareTransfer configuration file");
+                logger.info("No R66PrepareTransfer configuration file");
             }
         } else {
-            System.err.println("No R66PrepareTransfer support");
+            logger.info("No R66PrepareTransfer support");
         }
         FileBasedConfiguration.fileBasedConfiguration = configuration;
         // Start server.
@@ -109,7 +111,7 @@ public class ExecGatewayFtpServer {
         try {
             configuration.configureSnmp();
         } catch (FtpNoConnectionException e) {
-            System.err.println("Cannot start SNMP support: " + e.getMessage());
+        	logger.error("Cannot start SNMP support: " + e.getMessage());
         }
         logger.warn("FTP started " +
                 (configuration.getFtpInternalConfiguration().isUsingNativeSsl() ? "Implicit SSL On" :

--- a/src/main/java/org/waarp/gateway/ftp/ServerInitDatabase.java
+++ b/src/main/java/org/waarp/gateway/ftp/ServerInitDatabase.java
@@ -69,7 +69,7 @@ public class ServerInitDatabase {
             logger = WaarpLoggerFactory.getLogger(ServerInitDatabase.class);
         }
         if (!getParams(args)) {
-            logger.error("Need at least the configuration file as first argument then optionally\n"
+            System.err.println("Need at least the configuration file as first argument then optionally\n"
                     +
                     "    -initdb");
             if (DbConstant.gatewayAdmin != null && DbConstant.gatewayAdmin.isActive()) {
@@ -84,6 +84,7 @@ public class ServerInitDatabase {
                 new FilesystemBasedFileParameterImpl());
         try {
             if (!configuration.setConfigurationServerFromXml(args[0])) {
+                logger.error("Bad main configuration");
                 System.err.println("Bad main configuration");
                 if (DbConstant.gatewayAdmin != null) {
                     DbConstant.gatewayAdmin.close();
@@ -100,9 +101,9 @@ public class ServerInitDatabase {
                     logger.error("Cannot connect to database");
                     return;
                 }
-                System.out.println("End creation");
+                logger.debug("End creation");
             }
-            System.out.println("Load done");
+            logger.info("Load done");
         } finally {
             if (DbConstant.gatewayAdmin != null) {
                 DbConstant.gatewayAdmin.close();

--- a/src/main/java/org/waarp/gateway/ftp/database/model/DbModelH2.java
+++ b/src/main/java/org/waarp/gateway/ftp/database/model/DbModelH2.java
@@ -25,6 +25,8 @@ import org.waarp.common.database.DbSession;
 import org.waarp.common.database.exception.WaarpDatabaseNoConnectionException;
 import org.waarp.common.database.exception.WaarpDatabaseNoDataException;
 import org.waarp.common.database.exception.WaarpDatabaseSqlException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.gateway.ftp.database.DbConstant;
 import org.waarp.gateway.ftp.database.data.DbTransferLog;
 
@@ -35,6 +37,9 @@ import org.waarp.gateway.ftp.database.data.DbTransferLog;
  * 
  */
 public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
+
+    private WaarpLogger logger = WaarpLoggerFactory.getLogger(DbModelH2.class);
+
     /**
      * Create the object and initialize if necessary the driver
      * 
@@ -68,7 +73,7 @@ public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
             action += acolumns[acolumns.length - i].name() + ",";
         }
         action += acolumns[acolumns.length - 1].name() + "))";
-        System.out.println(action);
+        logger.debug(action);
         DbRequest request = new DbRequest(session);
         try {
             request.query(action);
@@ -88,7 +93,7 @@ public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
             action += icolumns[i].name() + ", ";
         }
         action += icolumns[icolumns.length - 1].name() + ")";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -104,7 +109,7 @@ public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
         action = "CREATE SEQUENCE IF NOT EXISTS " + DbTransferLog.fieldseq +
                 " START WITH " + (DbConstant.ILLEGALVALUE + 1) +
                 " MINVALUE " + (DbConstant.ILLEGALVALUE + 1);
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -114,7 +119,7 @@ public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
             // version <= 1.2.173
             action = "CREATE SEQUENCE IF NOT EXISTS " + DbTransferLog.fieldseq +
                     " START WITH " + (DbConstant.ILLEGALVALUE + 1);
-            System.out.println(action);
+            logger.debug(action);
             try {
                 request.query(action);
             } catch (WaarpDatabaseNoConnectionException e2) {
@@ -149,7 +154,7 @@ public class DbModelH2 extends org.waarp.common.database.model.DbModelH2 {
         } finally {
             request.close();
         }
-        System.out.println(action);
+        logger.debug(action);
     }
 
     @Override

--- a/src/main/java/org/waarp/gateway/ftp/database/model/DbModelMysql.java
+++ b/src/main/java/org/waarp/gateway/ftp/database/model/DbModelMysql.java
@@ -26,6 +26,8 @@ import org.waarp.common.database.DbSession;
 import org.waarp.common.database.exception.WaarpDatabaseNoConnectionException;
 import org.waarp.common.database.exception.WaarpDatabaseNoDataException;
 import org.waarp.common.database.exception.WaarpDatabaseSqlException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.gateway.ftp.database.DbConstant;
 import org.waarp.gateway.ftp.database.data.DbTransferLog;
 
@@ -36,6 +38,9 @@ import org.waarp.gateway.ftp.database.data.DbTransferLog;
  * 
  */
 public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
+
+    private WaarpLogger logger = WaarpLoggerFactory.getLogger(DbModelMysql.class);
+
     /**
      * Create the object and initialize if necessary the driver
      * 
@@ -72,7 +77,7 @@ public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
             action += acolumns[acolumns.length - i].name() + ",";
         }
         action += acolumns[acolumns.length - 1].name() + "))";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -91,7 +96,7 @@ public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
             action += icolumns[i].name() + ", ";
         }
         action += icolumns[icolumns.length - 1].name() + ")";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -113,7 +118,7 @@ public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
          */
         action = "CREATE TABLE Sequences (name VARCHAR(22) NOT NULL PRIMARY KEY," +
                 "seq BIGINT NOT NULL)";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -127,7 +132,7 @@ public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
         }
         action = "INSERT INTO Sequences (name, seq) VALUES ('" + DbTransferLog.fieldseq + "', " +
                 (DbConstant.ILLEGALVALUE + 1) + ")";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -158,7 +163,7 @@ public class DbModelMysql extends org.waarp.common.database.model.DbModelMysql {
         } finally {
             request.close();
         }
-        System.out.println(action);
+        logger.debug(action);
     }
 
     @Override

--- a/src/main/java/org/waarp/gateway/ftp/database/model/DbModelOracle.java
+++ b/src/main/java/org/waarp/gateway/ftp/database/model/DbModelOracle.java
@@ -25,6 +25,8 @@ import org.waarp.common.database.DbSession;
 import org.waarp.common.database.exception.WaarpDatabaseNoConnectionException;
 import org.waarp.common.database.exception.WaarpDatabaseNoDataException;
 import org.waarp.common.database.exception.WaarpDatabaseSqlException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.gateway.ftp.database.DbConstant;
 import org.waarp.gateway.ftp.database.data.DbTransferLog;
 
@@ -35,6 +37,9 @@ import org.waarp.gateway.ftp.database.data.DbTransferLog;
  * 
  */
 public class DbModelOracle extends org.waarp.common.database.model.DbModelOracle {
+
+    private WaarpLogger logger = WaarpLoggerFactory.getLogger(DbModelOracle.class);
+
     /**
      * Create the object and initialize if necessary the driver
      * 
@@ -70,7 +75,7 @@ public class DbModelOracle extends org.waarp.common.database.model.DbModelOracle
             action += acolumns[acolumns.length - i].name() + ",";
         }
         action += acolumns[acolumns.length - 1].name() + "))";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -88,7 +93,7 @@ public class DbModelOracle extends org.waarp.common.database.model.DbModelOracle
             action += icolumns[i].name() + ", ";
         }
         action += icolumns[icolumns.length - 1].name() + ")";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -104,7 +109,7 @@ public class DbModelOracle extends org.waarp.common.database.model.DbModelOracle
         action = "CREATE SEQUENCE " + DbTransferLog.fieldseq +
                 " MINVALUE " + (DbConstant.ILLEGALVALUE + 1) +
                 " START WITH " + (DbConstant.ILLEGALVALUE + 1);
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -138,7 +143,7 @@ public class DbModelOracle extends org.waarp.common.database.model.DbModelOracle
             request.close();
         }
 
-        System.out.println(action);
+        logger.debug(action);
     }
 
     @Override

--- a/src/main/java/org/waarp/gateway/ftp/database/model/DbModelPostgresql.java
+++ b/src/main/java/org/waarp/gateway/ftp/database/model/DbModelPostgresql.java
@@ -25,6 +25,8 @@ import org.waarp.common.database.DbSession;
 import org.waarp.common.database.exception.WaarpDatabaseNoConnectionException;
 import org.waarp.common.database.exception.WaarpDatabaseNoDataException;
 import org.waarp.common.database.exception.WaarpDatabaseSqlException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.gateway.ftp.database.DbConstant;
 import org.waarp.gateway.ftp.database.data.DbTransferLog;
 
@@ -35,6 +37,9 @@ import org.waarp.gateway.ftp.database.data.DbTransferLog;
  * 
  */
 public class DbModelPostgresql extends org.waarp.common.database.model.DbModelPostgresql {
+    
+    private WaarpLogger logger = WaarpLoggerFactory.getLogger(DbModelPostgresql.class);
+    
     /**
      * Create the object and initialize if necessary the driver
      * 
@@ -65,7 +70,7 @@ public class DbModelPostgresql extends org.waarp.common.database.model.DbModelPo
             action += acolumns[acolumns.length - i].name() + ",";
         }
         action += acolumns[acolumns.length - 1].name() + "))";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -84,7 +89,7 @@ public class DbModelPostgresql extends org.waarp.common.database.model.DbModelPo
             action += icolumns[i].name() + ", ";
         }
         action += icolumns[icolumns.length - 1].name() + ")";
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -100,7 +105,7 @@ public class DbModelPostgresql extends org.waarp.common.database.model.DbModelPo
         action = "CREATE SEQUENCE " + DbTransferLog.fieldseq +
                 " MINVALUE " + (DbConstant.ILLEGALVALUE + 1) +
                 " RESTART WITH " + (DbConstant.ILLEGALVALUE + 1);
-        System.out.println(action);
+        logger.debug(action);
         try {
             request.query(action);
         } catch (WaarpDatabaseNoConnectionException e) {
@@ -132,7 +137,7 @@ public class DbModelPostgresql extends org.waarp.common.database.model.DbModelPo
         } finally {
             request.close();
         }
-        System.out.println(action);
+        logger.debug(action);
     }
 
     @Override


### PR DESCRIPTION
Stderr is used when the service cannot start. If it can, there is no reason not to log.
This PR is just housekeeping.

To do later (because it might break some workflows, even if [xkcd #1172](https://xkcd.com/1172/)): use warning only for real warnings not to create false positive in monitoring systems.