### PR TITLE
revert mysql version to 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>6.0.5</version>
+      <version>[5.1.0,6.0.0)</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
As I stated in a comment of waarp/WaarpR66#212, version 6 of MySQL jdbc drivers are still in development and pose compatibility issues.
This reverts the drivers to version 5.1.* .